### PR TITLE
Update README with tile server usage policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 PHP library to easily get static image from OpenStreetMap with markers and lines.
 
+This project uses the [Tile Server](https://wiki.openstreetmap.org/wiki/Tile_servers) of the Open Streetmap Foundation which runs entirely on donated resources, see [Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/) for more information.
+
 ## ✨ Supporting
 
 ⭐ Star this repository to support this project. You will contribute to increase the visibility of this library 🙂
@@ -60,7 +62,6 @@ use \DantSu\OpenStreetMapStaticAPI\Markers;
 | [OpenStreetMap](./docs/classes/DantSu/OpenStreetMapStaticAPI/OpenStreetMap.md) | DantSu\OpenStreetMapStaticAPI\BoundingBox define the bounding box of the static map.|
 | [XY](./docs/classes/DantSu/OpenStreetMapStaticAPI/XY.md) | DantSu\OpenStreetMapStaticAPI\XY define X and Y pixel position for map, lines, markers.|
 
-This project uses the [Tile Server](https://wiki.openstreetmap.org/wiki/Tile_servers) of the Open Streetmap Foundation which runs entirely on donated resources, see [Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/) for more information.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ use \DantSu\OpenStreetMapStaticAPI\Markers;
 | [OpenStreetMap](./docs/classes/DantSu/OpenStreetMapStaticAPI/OpenStreetMap.md) | DantSu\OpenStreetMapStaticAPI\BoundingBox define the bounding box of the static map.|
 | [XY](./docs/classes/DantSu/OpenStreetMapStaticAPI/XY.md) | DantSu\OpenStreetMapStaticAPI\XY define X and Y pixel position for map, lines, markers.|
 
+This project uses the [Tile Server](https://wiki.openstreetmap.org/wiki/Tile_servers) of the Open Streetmap Foundation which runs entirely on donated resources, see [Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/) for more information.
+
 ## Contributing
 
 Please fork this repository and contribute back using pull requests.


### PR DESCRIPTION
Hey, great project! I researched the topic of static maps as well, thought about using this approach for a wordpress gutenberg block maybe.

During my research I stumbled about the fact, that Open Streetmap data is free for everyone to use, but tile servers are run by donations and have restrictions (It is also possible to setup own tile server or use commercial hosted services). 

Just added this line to make sure you give users all the necessary information on restrictions. :-) 

Best regards