### PR TITLE
Add support for curl options and fail curl on error in the TileLayer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "php": ">=7.0",
-    "dantsu/php-image-editor": "^1.2"
+    "dantsu/php-image-editor": "^1.3"
   },
   "autoload": {
     "psr-4": {

--- a/src/TileLayer.php
+++ b/src/TileLayer.php
@@ -45,16 +45,30 @@ class TileLayer
     protected $opacity = 1;
 
     /**
+     * @array $curlOptions Array of curl options
+     */
+    protected $curlOptions = [];
+
+    /**
+     * @bool $failCurlOnError If true, curl will throw an exception on error.
+     */
+    protected $failCurlOnError = false;
+
+    /**
      * TileLayer constructor
      * @param string $url tile server url with placeholders (`x`, `y`, `z`, `r`, `s`)
      * @param string $attributionText tile server attribution text
      * @param string $subdomains tile server subdomains
+     * @param array $curlOptions Array of curl options
+     * @param bool $failCurlOnError If true, curl will throw an exception on error.
      */
-    public function __construct(string $url, string $attributionText, string $subdomains = 'abc')
+    public function __construct(string $url, string $attributionText, string $subdomains = 'abc', array $curlOptions = [], bool $failCurlOnError = false)
     {
         $this->url = $url;
         $this->attributionText = $attributionText;
         $this->subdomains = \str_split($subdomains);
+        $this->curlOptions = $curlOptions;
+        $this->failCurlOnError = $failCurlOnError;
     }
 
     /**
@@ -115,7 +129,7 @@ class TileLayer
             return Image::newCanvas(256, 256);
         }
 
-        $tile = Image::fromCurl($this->getTileUrl($x, $y, $z));
+        $tile = Image::fromCurl($this->getTileUrl($x, $y, $z),$this->curlOptions, $this->failCurlOnError);
 
         if($this->opacity > 0 && $this->opacity < 1) {
             $tile->setOpacity($this->opacity);


### PR DESCRIPTION
Hi, Great little library you have!  I've began testing it yesterday.

As I was testing it, I noticed it didn't have much in the way of error checking on specifically the image retrieval.  A good example is when you put a typo in the TileLayer construct for the url use "https://tilezzzzzz.openstreetmap.org/{z}/{x}/{y}.png".  The image will get displayed with a grey background with nothing on it.  Some people may want it to function like this.

As such, made a construct option called failCurlOnError, and allowed curl option arrays in order to have more flexibility.

In my use case, if there is a failure, I have the code falling back to another method.

Thanks!