### PR TITLE
Allow usage of Image instance directly

### DIFF
--- a/src/Markers.php
+++ b/src/Markers.php
@@ -39,9 +39,19 @@ class Markers
      */
     private $coordinates = [];
 
-    public function __construct($pathImage)
+    /**
+     * Markers constructor.
+     *
+     * @param string|Image $image Path to the image or an instance of Image
+     */
+    public function __construct($image)
     {
-        $this->image = Image::fromPath($pathImage);
+        // If the pathImage is already an instance of Image, we use it directly
+        if ($image instanceof Image) {
+            $this->image = $image;
+        } else {
+            $this->image = Image::fromPath($image);
+        }
     }
 
     /**


### PR DESCRIPTION
Sometimes we need to use an actual image passed to `Markers`, for example when we need to downscale the image first. This PR allows users to do so, and supports backwards compatibility and fallback to building an image fromPath if the provided parameter is not an Image already.

This PR basically makes this possible:
```
        $markerImage = Image::fromPath($icon);

        // Resize the image to the icon dimensions
        $markerImage->downscaleProportion($this->iconWidth, $this->iconHeight);

        $generatedMarkers = new Markers($markerImage);
```